### PR TITLE
fix(package.json): remove parsed icons without specific target

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "module": "lib/esm/index.js",
   "files": [
     "lib",
-    "assets"
+    "assets",
+    "!lib/assets"
   ],
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",


### PR DESCRIPTION
We are creating a folder `lib/assets` with `cjs` output but it's not used because it's a duplication of the `cjs/` directory.